### PR TITLE
Commented health check on searxng dockerfile

### DIFF
--- a/docker/searxng/dockerfile
+++ b/docker/searxng/dockerfile
@@ -1,4 +1,4 @@
 FROM searxng/searxng:latest
 
 # Install wget for healthcheck
-RUN apt install -y wget bash
+# RUN apt install -y wget bash


### PR DESCRIPTION
The process "make run build" fails in the searng docker file image creation due the apt command is not found.

## Summary by Sourcery

Build:
- Comment out the `apt install -y wget bash` command in the Dockerfile to prevent build errors due to missing apt.